### PR TITLE
Fix issue with unread DMs not aligning properly

### DIFF
--- a/css/NotAnotherAnimeTheme.css
+++ b/css/NotAnotherAnimeTheme.css
@@ -415,7 +415,7 @@
     background-color: #25ace8;
 }
 
-[class~=guilds-wrapper] [class~=guilds] [class~=guild]:first-child,
+[class~=guilds-wrapper] [class~=guilds].not(.dms) [class~=guild]:first-child,
 [class~=guilds-wrapper] [class~=guilds] [class~=friends-online] {
     margin-left: auto;
 }
@@ -497,7 +497,7 @@
     border-right-width: .020833333in !important;
 }
 
-[class~=guilds-wrapper] [class~=guilds] [class~=guild]:first-child {
+[class~=guilds-wrapper] [class~=guilds].not(.dms) [class~=guild]:first-child {
     margin-right: auto;
 }
 
@@ -708,7 +708,7 @@
     border-left-style: solid;
 }
 
-[class~=guilds-wrapper] [class~=guilds] [class~=guild]:first-of-type {
+[class~=guilds-wrapper] [class~=guilds].not(.dms) [class~=guild]:first-of-type {
     border-left-width: 3.75pt;
 }
 
@@ -807,7 +807,7 @@
     border-bottom-width: 3.75pt;
 }
 
-[class~=guilds-wrapper] [class~=guilds] [class~=guild]:first-of-type {
+[class~=guilds-wrapper] [class~=guilds].not(.dms) [class~=guild]:first-of-type {
     border-right-width: 3.75pt;
 }
 


### PR DESCRIPTION
The first two unread DMs appear like this:
![mrlj5et](https://user-images.githubusercontent.com/14967932/37160833-25db5b64-22bf-11e8-9a6a-5f016e2e28d7.png)

This was caused by first-of-type being applied to the first unread DM and thus messing with the border and margin properties. These changes fix it to look like this: 

![rm5onfq](https://user-images.githubusercontent.com/14967932/37160898-44a84b06-22bf-11e8-9f38-c048809ccd88.png)